### PR TITLE
Retrieving data

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,7 @@
     "/node_modules"
   ],
   "dependencies": {
+    "google-apis": "GoogleWebComponents/google-apis#^1.0",
     "polymer": "Polymer/polymer#^1.0.0",
     "underscore": "~1.8.2"
   },

--- a/demo/index.html
+++ b/demo/index.html
@@ -11,8 +11,35 @@
 
     <p>An example of <code>&lt;rise-google-calendar&gt;</code>:</p>
 
-    <rise-google-calendar></rise-google-calendar>
+    <rise-google-calendar
+      calendar-id="en.canadian#holiday@group.v.calendar.google.com">
+    </rise-google-calendar>
 
-    <!-- TODO: demo content to come -->
+    <script>
+      (function () {
+        "use strict";
+
+        function webComponentsReady() {
+          window.removeEventListener("WebComponentsReady", webComponentsReady);
+
+          var calendar = document.querySelector("rise-google-calendar");
+
+          calendar.addEventListener("rise-google-calendar-response", function (e) {
+            console.log(e.detail.items);
+          });
+
+          calendar.addEventListener("rise-google-calendar-error", function (e) {
+            console.log(e.detail);
+          });
+
+          calendar.go();
+
+        }
+
+        window.addEventListener("WebComponentsReady", webComponentsReady);
+
+      })();
+    </script>
+
   </body>
 </html>

--- a/rise-google-calendar.html
+++ b/rise-google-calendar.html
@@ -1,4 +1,5 @@
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../google-apis/google-client-loader.html">
 
 <!--
 Element for retrieving Google Calendar event data.
@@ -12,6 +13,8 @@ Example:
 <dom-module id="rise-google-calendar">
 
   <template>
+    <google-client-loader id="calendar" name="calendar" version="v3"
+                          on-google-api-load="_apiLoaded"></google-client-loader>
     <content></content>
   </template>
 
@@ -23,6 +26,8 @@ Example:
     /* jshint newcap: false */
 
     "use strict";
+
+    var API_KEY = "AIzaSyBXxVK_IOV7LNQMuVVo_l7ZvN53ejN86zY";
 
     Polymer({
 
@@ -39,7 +44,18 @@ Example:
           value: ""
         },
 
+        /**
+         * `events` Returns the list of events on the calendar.
+         */
+        events: {
+          type: Array,
+          value: function() { return []; },
+          readOnly: true
+        }
+
       },
+
+      _requestPending: false,
 
       // Element Lifecycle
 
@@ -64,12 +80,82 @@ Example:
        * @event rise-google-calendar-error
        */
 
+      _prepareResponse: function (resp) {
+        var response = {};
+
+        // Provide an empty array if items property missing in response.
+        response.items = (resp.items) ? resp.items : [];
+
+        // TODO: provide calendar meta data (summary, description)?
+
+        return response;
+      },
+
+      _onEventsListError: function(error) {
+        // reset the value of events
+        this._setEvents([]);
+
+        this.fire("rise-google-calendar-error", error += " - Make sure your calendar has been made public.");
+
+        this._requestPending = false;
+      },
+
+      _onEventsListResponse: function(resp) {
+        var responseData = this._prepareResponse(resp);
+
+        // use setter method to apply events value because this property is read only
+        this._setEvents(responseData.items);
+
+        this.fire("rise-google-calendar-response", responseData);
+
+        this._requestPending = false;
+      },
+
+      _getParams: function() {
+        var params = {};
+
+        // required in every request
+        params.key = API_KEY;
+        params.calendarId = this.calendarId;
+        params.singleEvents = true;
+        params.orderBy = "startTime";
+
+        return params;
+      },
+
       /**
        * Performs a request to obtain the Google Calendar events data
        *
        */
       go: function() {
-        // TODO: logic to come
+        var request;
+
+        if (this.calendarId === "") {
+          return;
+        }
+
+        if (!this.$.calendar.api) {
+          // in case go() function is called before api is loaded
+          this._requestPending = true;
+          return;
+        }
+
+        request = this.$.calendar.api.events.list(this._getParams());
+
+        request.execute(function(resp) {
+          if (resp.error) {
+            this._onEventsListError(resp.message);
+          } else {
+            this._onEventsListResponse(resp);
+          }
+        }.bind(this));
+      },
+
+      _apiLoaded: function () {
+        if (this._requestPending) {
+          this._requestPending = false;
+          this.go();
+        }
       }
 
     });

--- a/test/data/events.js
+++ b/test/data/events.js
@@ -1,0 +1,106 @@
+// Full item object reference
+// https://developers.google.com/google-apps/calendar/v3/reference/events#resource
+
+var eventsData = {
+  "kind": "calendar#events",
+  "etag": "1437471204000000",
+  "summary": "Holidays in Canada",
+  "description": "Holidays and Observances in Canada",
+  "updated": "2015-07-21T09:33:24.000Z",
+  "timeZone": "UTC",
+  "accessRole": "reader",
+  "defaultReminders": [],
+  items: [
+    {
+      "kind": "calendar#event",
+      "etag": "2778463594000000",
+      "id": "20140101_60o30cho6co30c1g60o30dr4ck",
+      "status": "confirmed",
+      "htmlLink": "https://www.google.com/calendar/event?eid=MjAxNDAxMDFfNjBvMzBjaG82Y28zMGMxZzYwbzMwZHI0Y2sgZW4uY2FuYWRpYW4jaG9saWRheUB2",
+      "created": "2014-01-09T01:43:17.000Z",
+      "updated": "2014-01-09T01:43:17.000Z",
+      "summary": "New Year's Day",
+      "creator": {
+        "email": "en.canadian#holiday@group.v.calendar.google.com",
+        "displayName": "Holidays in Canada",
+        "self": true
+      },
+      "organizer": {
+        "email": "en.canadian#holiday@group.v.calendar.google.com",
+        "displayName": "Holidays in Canada",
+        "self": true
+      },
+      "start": {
+        "date": "2014-01-01"
+      },
+      "end": {
+        "date": "2014-01-02"
+      },
+      "transparency": "transparent",
+      "visibility": "public",
+      "iCalUID": "20140101_60o30cho6co30c1g60o30dr4ck@google.com",
+      "sequence": 0
+    },
+    {
+      "kind": "calendar#event",
+      "etag": "2778463660000000",
+      "id": "20150406_60o30eb26go30c1g60o30dr4co",
+      "status": "confirmed",
+      "htmlLink": "https://www.google.com/calendar/event?eid=MjAxNTA0MDZfNjBvMzBlYjI2Z28zMGMxZzYwbzMwZHI0Y28gZW4uY2FuYWRpYW4jaG9saWRheUB2",
+      "created": "2014-01-09T01:43:50.000Z",
+      "updated": "2014-01-09T01:43:50.000Z",
+      "summary": "National Tartan Day",
+      "creator": {
+        "email": "en.canadian#holiday@group.v.calendar.google.com",
+        "displayName": "Holidays in Canada",
+        "self": true
+      },
+      "organizer": {
+        "email": "en.canadian#holiday@group.v.calendar.google.com",
+        "displayName": "Holidays in Canada",
+        "self": true
+      },
+      "start": {
+        "date": "2015-04-06"
+      },
+      "end": {
+        "date": "2015-04-07"
+      },
+      "transparency": "transparent",
+      "visibility": "public",
+      "iCalUID": "20150406_60o30eb26go30c1g60o30dr4co@google.com",
+      "sequence": 0
+    },
+    {
+      "kind": "calendar#event",
+      "etag": "2858272502000000",
+      "id": "20160523_60o30cho70o30e1g60o30dr560",
+      "status": "confirmed",
+      "htmlLink": "https://www.google.com/calendar/event?eid=MjAxNjA1MjNfNjBvMzBjaG83MG8zMGUxZzYwbzMwZHI1NjAgZW4uY2FuYWRpYW4jaG9saWRheUB2",
+      "created": "2015-04-15T22:17:31.000Z",
+      "updated": "2015-04-15T22:17:31.000Z",
+      "summary": "Victoria Day",
+      "creator": {
+        "email": "en.canadian#holiday@group.v.calendar.google.com",
+        "displayName": "Holidays in Canada",
+        "self": true
+      },
+      "organizer": {
+        "email": "en.canadian#holiday@group.v.calendar.google.com",
+        "displayName": "Holidays in Canada",
+        "self": true
+      },
+      "start": {
+        "date": "2016-05-23"
+      },
+      "end": {
+        "date": "2016-05-24"
+      },
+      "transparency": "transparent",
+      "visibility": "public",
+      "iCalUID": "20160523_60o30cho70o30e1g60o30dr560@google.com",
+      "sequence": 0,
+      "description": "Public holiday in: Alberta, British Columbia, Manitoba, New Brunswick, Newfoundland and Labrador, Northwest Territories, Ontario, Prince Edward Island, Saskatchewan, Yukon"
+    }
+  ]
+};

--- a/test/rise-google-calendar-unit.html
+++ b/test/rise-google-calendar-unit.html
@@ -13,12 +13,137 @@
 
     <rise-google-calendar></rise-google-calendar>
 
+    <script src="data/events.js"></script>
+
     <script>
-      var myEl = document.querySelector('rise-google-calendar');
+      var calendarEl = document.querySelector('rise-google-calendar');
 
       suite('<rise-google-calendar>', function() {
 
-        // TODO: tests to come
+        var clock, responded, listener;
+
+        suiteSetup(function() {
+          clock = sinon.useFakeTimers();
+        });
+
+        suiteTeardown(function() {
+          clock.restore();
+        });
+
+        setup(function() {
+          responded = false;
+        });
+
+        suite("_onEventsListError", function () {
+          var errorMessage = "Not Found";
+
+          test("should fire 'rise-google-calendar-error' with message", function(done) {
+            listener = function(response) {
+              responded = true;
+
+              assert.equal(response.detail, errorMessage + " - Make sure your calendar has been made public.");
+
+              calendarEl.removeEventListener("rise-google-calendar-error", listener);
+            };
+
+            calendarEl.addEventListener("rise-google-calendar-error", listener);
+            calendarEl._onEventsListError(errorMessage);
+            assert.isTrue(responded);
+            done();
+          });
+        });
+
+        suite("_onEventsListResponse", function () {
+          teardown(function() {
+            calendarEl._setEvents([]);
+          });
+
+          test("should fire rise-google-sheet-response and set events property", function(done) {
+            listener = function(response) {
+              responded = true;
+
+              assert.property(response.detail, "items", "detail.items property exists");
+              assert.isArray(response.detail.items, "detail.items is an Array");
+              assert.deepEqual(response.detail.items, eventsData.items, "detail.items data is correct");
+
+              calendarEl.removeEventListener("rise-google-calendar-response", listener);
+            };
+
+            calendarEl.addEventListener("rise-google-calendar-response", listener);
+            calendarEl._onEventsListResponse(eventsData);
+
+            assert.deepEqual(calendarEl.events, eventsData.items, "events property is set correctly");
+            assert.isTrue(responded);
+
+            done();
+          });
+
+        });
+
+        suite("_apiLoaded", function () {
+          teardown(function() {
+            calendarEl._requestPending = false;
+            calendarEl.go.restore();
+          });
+
+          test("should call go() when request is pending", function () {
+            var goStub = sinon.stub(calendarEl, "go", function (){});
+
+            calendarEl._requestPending = true;
+            calendarEl._apiLoaded();
+
+            assert(goStub.calledOnce);
+          });
+
+          test("should not call go() when no request is pending", function () {
+            var goStub = sinon.stub(calendarEl, "go", function (){});
+
+            calendarEl._apiLoaded();
+
+            assert.equal(goStub.callCount, 0);
+          });
+        });
+
+        suite("_prepareResponse", function() {
+          test("should return an Array of event objects", function() {
+            var response = calendarEl._prepareResponse(eventsData);
+
+            assert.property(response, "items");
+            assert.isArray(response.items);
+            assert.deepEqual(response.items, eventsData.items);
+          });
+        });
+
+        suite("_getParams", function() {
+          var params;
+
+          teardown(function() {
+            calendarEl.calendarId = "";
+          });
+
+          test("should return an object that contains required param values", function () {
+            calendarEl.calendarId = "abc123";
+
+            params = calendarEl._getParams();
+
+            assert.property(params, "key");
+            assert.isString(params.key);
+            assert.equal(params.key, "AIzaSyBXxVK_IOV7LNQMuVVo_l7ZvN53ejN86zY");
+
+            assert.property(params, "singleEvents");
+            assert.isBoolean(params.singleEvents);
+            assert.equal(params.singleEvents, true);
+
+            assert.property(params, "orderBy");
+            assert.isString(params.orderBy);
+            assert.equal(params.orderBy, "startTime");
+
+            assert.property(params, "calendarId");
+            assert.isString(params.calendarId);
+            assert.equal(params.calendarId, "abc123");
+          });
+
+        });
 
       });
     </script>


### PR DESCRIPTION
- Using `<google-client-loader>` Polymer component to load the Calendar API
- Defined private constant `API_KEY` to use for Events list query request
- Providing `events` property for binding purposes
- Executing Events list query request, handling response and error
- Test coverage
	- data file added for mocking data returned from a Events list request of the Calendar API
	- unit tests added for functionality added
- demo file updated to log data