### PR TITLE
Adding support for a refresh

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -13,6 +13,7 @@
 
     <rise-google-calendar
       calendar-id="en.canadian#holiday@group.v.calendar.google.com"
+      refresh="5"
       start-date="2015-01-01" end-date="2015-12-31"
       timezone="America/Vancouver">
     </rise-google-calendar>

--- a/rise-google-calendar.html
+++ b/rise-google-calendar.html
@@ -79,6 +79,14 @@ Example:
         timezone: {
           type: String,
           value: ""
+        },
+
+        /**
+         * `refresh` The number of minutes before another request will be made.
+         */
+        refresh: {
+          type: Number,
+          value: 0
         }
 
       },
@@ -107,6 +115,21 @@ Example:
        * @param {Object} detail
        * @event rise-google-calendar-error
        */
+
+      _startTimer: function() {
+        var refreshFn = this.go,
+          self = this;
+
+        this.refresh = parseInt(this.refresh, 10);
+
+        if (!isNaN(this.refresh) && this.refresh !== 0) {
+          this.refresh = (this.refresh < 5) ? 5 : this.refresh;
+
+          this.debounce("refresh", function () {
+            refreshFn.call(self);
+          }, this.refresh * 60000);
+        }
+      },
 
       _prepareResponse: function (resp) {
         var response = {};
@@ -144,6 +167,13 @@ Example:
         this._setEvents([]);
 
         this.fire("rise-google-calendar-error", this._prepareError(type, error));
+
+        this._requestPending = false;
+
+        if (type === "api") {
+          // if error is api related, proceed with refresh timer in case their calendar visibility gets set to public
+          this._startTimer();
+        }
       },
 
       _onEventsListResponse: function(resp) {
@@ -153,6 +183,9 @@ Example:
         this._setEvents(responseData.items);
 
         this.fire("rise-google-calendar-response", responseData);
+
+        this._requestPending = false;
+        this._startTimer();
       },
 
       _validateTimezone: function() {
@@ -231,7 +264,7 @@ Example:
       go: function() {
         var request;
 
-        if (this.calendarId === "") {
+        if (this.calendarId === "" || this._requestPending) {
           return;
         }
 
@@ -243,6 +276,8 @@ Example:
 
         if (this._isValid()) {
           request = this.$.calendar.api.events.list(this._getParams());
+
+          this._requestPending = true;
 
           request.execute(function(resp) {
             if (resp.error) {

--- a/test/rise-google-calendar-unit.html
+++ b/test/rise-google-calendar-unit.html
@@ -61,14 +61,33 @@
         });
 
         suite("_onError", function () {
+          var startTimerStub;
+
           test("should make call to _prepareError for retrieving error message", function() {
             var prepStub = sinon.stub(calendarEl, "_prepareError", function(){});
 
             calendarEl._onError(null, "timezone");
 
             assert.isTrue(prepStub.calledWithExactly("timezone", null));
-
             calendarEl._prepareError.restore();
+          });
+
+          test("should make call to _startTimer if error type is 'api'", function() {
+            startTimerStub = sinon.stub(calendarEl, "_startTimer", function(){});
+
+            calendarEl._onError(null, "api");
+
+            assert(startTimerStub.calledOnce);
+            calendarEl._startTimer.restore();
+          });
+
+          test("should not make call to _startTimer if error type is not 'api'", function() {
+            startTimerStub = sinon.stub(calendarEl, "_startTimer", function(){});
+
+            calendarEl._onError(null, "range");
+
+            assert.equal(startTimerStub.callCount, 0);
+            calendarEl._startTimer.restore();
           });
 
           test("should fire 'rise-google-calendar-error' with message", function(done) {
@@ -278,6 +297,48 @@
             timezone = calendarEl._validateTimezone();
             assert.isFalse(timezone);
           });
+        });
+
+        suite("_startTimer", function() {
+          var goStub;
+
+          setup(function () {
+            goStub = sinon.stub(calendarEl, "go", function () {});
+          });
+
+          teardown(function() {
+            calendarEl.refresh = 0;
+            calendarEl.go.restore();
+          });
+
+          test("should not make a new request for data due to refresh value being 0", function() {
+            calendarEl._startTimer();
+
+            assert.equal(goStub.callCount, 0);
+          });
+
+          test("should not make a new request for data due to refresh value not being a number", function() {
+            calendarEl.refresh = "20d";
+            calendarEl._startTimer();
+
+            assert.equal(goStub.callCount, 0);
+          });
+
+          test("should enforce a minimum refresh interval of 5 (minutes)", function() {
+            calendarEl.refresh = 2;
+            calendarEl._startTimer();
+
+            assert.equal(calendarEl.refresh, 5);
+          });
+
+          test("should make a new request for data", function() {
+            calendarEl.refresh = 30;
+            calendarEl._startTimer();
+
+            clock.tick(1800000);
+            assert(goStub.calledOnce);
+          });
+
         });
 
       });


### PR DESCRIPTION
- Added `refresh` property with a minimum of 5 minutes
- Refresh timer will start again (if set) after a successful response and after an error if the error is api related
- Demo using `refresh` attribute
- Added unit test coverage