### PR TITLE
Adding offline caching support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-google-calendar",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "authors": [
     "Stuart Lees <stuart.lees@risevision.com>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-google-calendar",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Rise Vision web component for retrieving Google Calendar event data.",
   "scripts": {
     "test": "gulp test",

--- a/rise-google-calendar.html
+++ b/rise-google-calendar.html
@@ -69,6 +69,16 @@ For example, to apply Toronto, Canada timezone to all events provided in the res
 
     var API_KEY = "AIzaSyBXxVK_IOV7LNQMuVVo_l7ZvN53ejN86zY";
 
+    var LOCAL_STORAGE_NAME = "risecalendar";
+
+    function supportsLocalStorage() {
+      try {
+        return "localStorage" in window && window.localStorage !== null;
+      } catch (e) {
+        return false;
+      }
+    }
+
     Polymer({
 
       is: "rise-google-calendar",
@@ -130,12 +140,6 @@ For example, to apply Toronto, Canada timezone to all events provided in the res
 
       _requestPending: false,
 
-      // Element Lifecycle
-
-      ready: function() {
-
-      },
-
       // Element Behavior
 
       /**
@@ -152,6 +156,59 @@ For example, to apply Toronto, Canada timezone to all events provided in the res
        * @param {Object} detail
        * @event rise-google-calendar-error
        */
+
+      _getCachedData: function () {
+        if (supportsLocalStorage()) {
+          // retrieve cached data and parse back
+          return JSON.parse(localStorage.getItem(LOCAL_STORAGE_NAME));
+        }
+
+        return null;
+      },
+
+      _setCachedData: function (data) {
+        if (supportsLocalStorage()) {
+          localStorage.setItem(LOCAL_STORAGE_NAME, JSON.stringify(data));
+        }
+      },
+
+      _handleOffline: function () {
+        var cachedData = this._getCachedData();
+
+        if (cachedData) {
+          this._setEvents(cachedData.items);
+
+          this.fire("rise-google-calendar-response", cachedData);
+
+          this._requestPending = false;
+          this._startTimer();
+
+        } else {
+          this._onError(null, "offline");
+        }
+      },
+
+      _offlineCheck: function () {
+        var jsApi = this.$.calendar.querySelector("google-js-api");
+
+        if (jsApi && !jsApi.libraryLoaded && jsApi.libraryErrorMessage !== null) {
+          // no internet, offline
+          this._handleOffline();
+        }
+        else {
+          // start another check for being offline
+          this._startOfflineTimer();
+        }
+      },
+
+      _startOfflineTimer: function() {
+        var fn = this._offlineCheck,
+          self = this;
+
+        this.debounce("offline", function () {
+          fn.call(self);
+        }, 500);
+      },
 
       _startTimer: function() {
         var refreshFn = this.go,
@@ -194,6 +251,9 @@ For example, to apply Toronto, Canada timezone to all events provided in the res
           case "timezone":
             message = "Invalid timezone value.";
             break;
+          case "offline":
+            message = "A network error occurred and no cached data available";
+            break;
         }
 
         return message;
@@ -202,6 +262,11 @@ For example, to apply Toronto, Canada timezone to all events provided in the res
       _onError: function(error, type) {
         // reset the value of events
         this._setEvents([]);
+
+        // if cached data exists, remove it
+        if (this._getCachedData()) {
+          localStorage.removeItem(LOCAL_STORAGE_NAME);
+        }
 
         this.fire("rise-google-calendar-error", this._prepareError(type, error));
 
@@ -215,6 +280,9 @@ For example, to apply Toronto, Canada timezone to all events provided in the res
 
       _onEventsListResponse: function(resp) {
         var responseData = this._prepareResponse(resp);
+
+        // cache the data if possible
+        this._setCachedData(responseData);
 
         // use setter method to apply events value because this property is read only
         this._setEvents(responseData.items);
@@ -318,7 +386,13 @@ For example, to apply Toronto, Canada timezone to all events provided in the res
 
           request.execute(function(resp) {
             if (resp.error) {
-              this._onError(resp.message, "api");
+              if (resp.code === -1) {
+                // A network error occurred, component is now running offline
+                this._handleOffline();
+              }
+              else {
+                this._onError(resp.message, "api");
+              }
             } else {
               this._onEventsListResponse(resp);
             }
@@ -328,10 +402,21 @@ For example, to apply Toronto, Canada timezone to all events provided in the res
       },
 
       _apiLoaded: function () {
+        // cancel checking for offline status
+        if (this.isDebouncerActive("offline")) {
+          this.cancelDebouncer("offline");
+        }
+
         if (this._requestPending) {
           this._requestPending = false;
           this.go();
         }
+      },
+
+      // Element Lifecycle
+
+      ready: function() {
+        this._startOfflineTimer();
       }
 
     });

--- a/test/mock/google-calendar-api-mock.js
+++ b/test/mock/google-calendar-api-mock.js
@@ -28,16 +28,18 @@
     window.calendarAPIResp = {};
   }
 
-  window.setCalendarAPIResponse = function(successful){
+  window.setCalendarAPIResponse = function(successful, code){
     if (successful) {
       window.calendarAPIResp = _.clone(eventsData);
       calendarAPIResp.result = _.clone(eventsData);
     } else {
       window.calendarAPIResp = {
         error: {
-          message: "Not Found"
+          message: code === -1 ? "A network error occurred, and the request could not be completed." : "Not Found",
+          code: code
         },
-        message: "Not Found"
+        message: code === -1 ? "A network error occurred, and the request could not be completed." : "Not Found",
+        code: code
       }
     }
   };

--- a/test/rise-google-calendar-integration.html
+++ b/test/rise-google-calendar-integration.html
@@ -22,7 +22,20 @@
 
   suite('<rise-google-calendar>', function() {
 
-    var responseHandler;
+    var responseHandler, clock;
+
+    // Runs for every suite.
+    suiteSetup(function() {
+      clock = sinon.useFakeTimers();
+    });
+
+    suiteTeardown(function() {
+      clock.restore();
+    });
+
+    setup(function() {
+      localStorage.removeItem("risecalendar"); // clear localStorage
+    });
 
     suite("request data", function() {
       teardown(function () {
@@ -59,7 +72,7 @@
         };
 
         calendarEl.calendarId = "abc123";
-        window.setCalendarAPIResponse(false); // force a unsuccessful api response
+        window.setCalendarAPIResponse(false, 404); // force a unsuccessful api response
         calendarEl.addEventListener("rise-google-calendar-error", responseHandler);
         calendarEl.go();
       });
@@ -99,18 +112,52 @@
 
       });
 
-      test("should not execute further request when there is one pending a response", function() {
-        var requestStub = sinon.stub(calendarEl.$.calendar.api.events, "list", function (){
-          return {execute: function(){}}
-        });
+    });
+
+    suite("offline cached data", function () {
+
+      teardown(function () {
+        calendarEl.calendarId = "";
+        calendarEl.refresh = 0;
+      });
+
+      test("should return error message when network error and no cached data", function (done) {
+        responseHandler = function(response) {
+          calendarEl.removeEventListener("rise-google-calendar-error", responseHandler);
+
+          assert.equal(response.detail, "A network error occurred and no cached data available");
+
+          done();
+        };
 
         calendarEl.calendarId = "abc123";
-        calendarEl.go();
-        calendarEl.go();
+
+        calendarEl.addEventListener("rise-google-calendar-error", responseHandler);
+        window.setCalendarAPIResponse(false, -1); // force an offline response
         calendarEl.go();
 
-        assert(requestStub.calledOnce);
-        calendarEl.$.calendar.api.events.list.restore();
+      });
+
+      test("should return an Array of cached event objects upon refresh and a network error", function (done) {
+        responseHandler = function(response) {
+          calendarEl.removeEventListener("rise-google-calendar-response", responseHandler);
+
+          assert.deepEqual(response.detail.items, eventsData.items);
+
+          done();
+        };
+
+        calendarEl.calendarId = "abc123";
+        calendarEl.refresh = 5;
+
+        window.setCalendarAPIResponse(true); // force a successful response
+        calendarEl.go();
+
+        calendarEl.addEventListener("rise-google-calendar-response", responseHandler);
+        window.setCalendarAPIResponse(false, -1); // force an offline response
+
+        clock.tick(300000); // refresh will occur
+
       });
 
     });

--- a/test/rise-google-calendar-unit.html
+++ b/test/rise-google-calendar-unit.html
@@ -112,7 +112,9 @@
             calendarEl._setEvents([]);
           });
 
-          test("should fire rise-google-sheet-response and set events property", function(done) {
+          test("should fire rise-google-sheet-response, set events property, and save to local storage", function(done) {
+            var setCachedDataStub = sinon.stub(calendarEl, "_setCachedData", function () {});
+
             listener = function(response) {
               responded = true;
 
@@ -126,8 +128,11 @@
             calendarEl.addEventListener("rise-google-calendar-response", listener);
             calendarEl._onEventsListResponse(eventsData);
 
+            assert(setCachedDataStub.calledOnce, "call to _setCachedData is made");
             assert.deepEqual(calendarEl.events, eventsData.items, "events property is set correctly");
             assert.isTrue(responded);
+
+            calendarEl._setCachedData.restore();
 
             done();
           });
@@ -135,14 +140,18 @@
         });
 
         suite("_apiLoaded", function () {
+          var goStub;
+
+          setup(function() {
+            goStub = sinon.stub(calendarEl, "go", function (){});
+          });
+
           teardown(function() {
             calendarEl._requestPending = false;
             calendarEl.go.restore();
           });
 
           test("should call go() when request is pending", function () {
-            var goStub = sinon.stub(calendarEl, "go", function (){});
-
             calendarEl._requestPending = true;
             calendarEl._apiLoaded();
 
@@ -150,8 +159,6 @@
           });
 
           test("should not call go() when no request is pending", function () {
-            var goStub = sinon.stub(calendarEl, "go", function (){});
-
             calendarEl._apiLoaded();
 
             assert.equal(goStub.callCount, 0);
@@ -338,6 +345,67 @@
             clock.tick(1800000);
             assert(goStub.calledOnce);
           });
+
+        });
+
+        suite("_startOfflineTimer", function() {
+
+          test("should make a call to _offlineCheck after 500ms", function() {
+            var offlineStub = sinon.stub(calendarEl, "_offlineCheck", function () {});
+            calendarEl._startOfflineTimer();
+
+            clock.tick(500);
+            assert(offlineStub.calledOnce);
+            calendarEl._offlineCheck.restore();
+          });
+
+        });
+
+        suite("_handleOffline", function () {
+          var cachedDataStub;
+
+          teardown(function () {
+            calendarEl._getCachedData.restore();
+            calendarEl._setEvents([]);
+          });
+
+          test("should fire rise-google-sheet-response and set events property with cached data", function (done) {
+            cachedDataStub = sinon.stub(calendarEl, "_getCachedData", function() {
+              return {
+                items: eventsData.items
+              };
+            });
+
+            listener = function(response) {
+              responded = true;
+
+              assert.deepEqual(response.detail.items, eventsData.items, "detail.items data is correct");
+
+              calendarEl.removeEventListener("rise-google-calendar-response", listener);
+            };
+
+            calendarEl.addEventListener("rise-google-calendar-response", listener);
+            calendarEl._handleOffline();
+
+            assert.deepEqual(calendarEl.events, eventsData.items, "events property is set correctly");
+            assert.isTrue(responded);
+
+            done();
+          });
+
+          test("should make call to _onError due to no cached data", function () {
+            var errorStub = sinon.stub(calendarEl, "_onError", function () {});
+
+            cachedDataStub = sinon.stub(calendarEl, "_getCachedData", function() {
+              return null;
+            });
+
+            calendarEl._handleOffline();
+            assert(errorStub.calledOnce);
+
+            calendarEl._onError.restore();
+          });
+
 
         });
 


### PR DESCRIPTION
- When a successful response is provided from API request, data is cached using `localStorage`
- When API or validation errors occur, any cached data is removed
- A timer gets started upon `ready` lifecycle state to check for offline status which it does via the `libraryLoaded` and `libraryErrorMessage` properties of `google-js-api` instance of `google-client-loader`
- Upon network error and cached data exists, it processes a normal response ("rise-google-calendar-response") providing the cached data. If no cached data available, it processes as an error ("rise-google-calendar-error").
- test coverage added
- version bump